### PR TITLE
Fix compatibility with latest SoftwareSerial and DSMR 4.2.2

### DIFF
--- a/esp8266_p1meter.ino
+++ b/esp8266_p1meter.ino
@@ -23,7 +23,7 @@ WiFiClient espClient;
 PubSubClient mqtt_client(espClient);
 
 // * Initiate Software Serial
-SoftwareSerial p1_serial(P1_SERIAL_RX, -1, true, P1_MAXLINELENGTH); // (RX, TX. inverted, buffer)
+SoftwareSerial p1_serial(P1_SERIAL_RX, -1, true); // (RX, TX. inverted)
 
 // **********************************
 // * WIFI                           *

--- a/settings.h
+++ b/settings.h
@@ -9,7 +9,7 @@
 #define P1_SERIAL_RX D2
 
 // * Max telegram length
-#define P1_MAXLINELENGTH 64
+#define P1_MAXLINELENGTH 1024
 
 // * The hostname of our little creature
 #define HOSTNAME "p1meter"


### PR DESCRIPTION
Thanks for your cool project! After changing two small things, I've now got my energy in HA :+1: 

Firstly, the current version of te SoftwareSerial library doesn't require (nor accept) an buffersize in the initialization of the object. Simply removing this argument fixes compilation.

Secondly, my Kaifa MA105C (DSMR 4.2.2) spits out quite bit more than the 64 char buffer could hold which caused the CRC check to fail. By increasing the buffersize to 1024 the line is being read in correctly and the CRC passes. 512 might also just about have been enough, but since this sketch isn't too complicated there is a lot of free memory left anyway.
(You could now also update the README and such to reflect 4.2.2 compatibility, but I'll leave that up to you - 4.2.2 is a subversion of 4.2)